### PR TITLE
added a way to get the whole set's price at once

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-application: matgPrices
+application: mtgPrices
 version: 2
 runtime: python27
 api_version: 1

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-application: magictcgprices
+application: matgPrices
 version: 2
 runtime: python27
 api_version: 1

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
-application: mtgPrices
-version: 2
+application: mtgprices
+version: 1
 runtime: python27
 api_version: 1
 threadsafe: yes

--- a/main.py
+++ b/main.py
@@ -85,11 +85,11 @@ class TCGPriceCheckHandler(webapp2.RequestHandler):
 class TCGSetPriceHandler(webapp2.RequestHandler):
     def get(self):
         cardSet = self.request.get('cardset')
-        # retVal = None
-        # retVal = memcache.get('TCG ' + cardSet)
-        # if retVal is None:
-        retVal = getTCGPlayerSetPrices(cardSet)
-        memcache.add('TCG ' + cardSet, retVal, 300)
+        retVal = None
+        retVal = memcache.get('TCG ' + cardSet)
+        if retVal is None:
+            retVal = getTCGPlayerSetPrices(cardSet)
+            memcache.add('TCG ' + cardSet, retVal, 300)
         self.response.headers['Content-Type'] = 'application/json'
         self.response.out.write(json.dumps(retVal))
 

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ class TCGSetPriceHandler(webapp2.RequestHandler):
         if retVal is None:
             retVal = getTCGPlayerSetPrices(cardSet)
             memcache.add('TCG ' + cardSet, retVal, 300)
-        self.response.headers['Content-Type'] = 'application/json'
+        self.response.headers['Content-Type'] = 'application/json; charset=utf-8'
         self.response.out.write(json.dumps(retVal))
 
 

--- a/main.py
+++ b/main.py
@@ -82,6 +82,18 @@ class TCGPriceCheckHandler(webapp2.RequestHandler):
         self.response.headers['Content-Type'] = 'application/json'
         self.response.out.write(json.dumps(retVal))
 
+class TCGSetPriceHandler(webapp2.RequestHandler):
+    def get(self):
+        cardSet = self.request.get('cardset')
+        retVal = None
+        retVal = memcache.get('TCG ' + cardSet)
+        if retVal is None:
+            retVal = getTCGPlayerSetPrices(cardSet)
+            memcache.add('TCG ' + cardSet, retVal, 300)
+        self.response.headers['Content-Type'] = 'application/json'
+        self.response.out.write(json.dumps(retVal))
+
+
 class EbayPriceCheckHandler(webapp2.RequestHandler):
     def get(self):
         cardName = self.request.get('cardname')
@@ -105,6 +117,6 @@ class MainHandler(webapp2.RequestHandler):
         self.response.out.write("Hello world")
 
 app = webapp2.WSGIApplication([
-    ('/', MainHandler), ('/api/tcgplayer/price.json', TCGPriceCheckHandler), ('/api/ebay/price.json', EbayPriceCheckHandler), 
+    ('/', MainHandler), ('/api/tcgplayer/price.json', TCGPriceCheckHandler), ('/api/tcgplayer/setPrices.json', TCGSetPriceHandler), ('/api/ebay/price.json', EbayPriceCheckHandler), 
     ('/api/cfb/price.json', CFBPriceCheckHandler), ('/api/images/imageurl.json', GetImageURLHandler)
 ], debug=True)

--- a/main.py
+++ b/main.py
@@ -85,11 +85,11 @@ class TCGPriceCheckHandler(webapp2.RequestHandler):
 class TCGSetPriceHandler(webapp2.RequestHandler):
     def get(self):
         cardSet = self.request.get('cardset')
-        retVal = None
-        retVal = memcache.get('TCG ' + cardSet)
-        if retVal is None:
-            retVal = getTCGPlayerSetPrices(cardSet)
-            memcache.add('TCG ' + cardSet, retVal, 300)
+        # retVal = None
+        # retVal = memcache.get('TCG ' + cardSet)
+        # if retVal is None:
+        retVal = getTCGPlayerSetPrices(cardSet)
+        memcache.add('TCG ' + cardSet, retVal, 300)
         self.response.headers['Content-Type'] = 'application/json'
         self.response.out.write(json.dumps(retVal))
 

--- a/scraper.py
+++ b/scraper.py
@@ -101,26 +101,26 @@ def getTCGPlayerSetPrices(cardSet):
         CardName = rawHTML[startNameIndex:endNameIndex]
         index = endNameIndex
 
-        #   Scrape for the low price
+        #   Scrape for the high price
         tempIndex = rawHTML.find("<td width=55", index)
-        startLowIndex = rawHTML.find("$", tempIndex)
-        endLowIndex = rawHTML.find("</font>", startLowIndex)
-        index = endLowIndex
-        lowPrice = rawHTML[startLowIndex:endLowIndex]
+        startHighIndex = rawHTML.find("$", tempIndex)
+        endHighIndex = rawHTML.find("</font>", startHighIndex)
+        index = endHighIndex
+        highPrice = rawHTML[startHighIndex:endHighIndex]
 
         #   Scrape for the mid price
-        tempIndex = rawHTML.find("<td width=55", endLowIndex)
+        tempIndex = rawHTML.find("<td width=55", endHighIndex)
         startMidIndex = rawHTML.find("$", tempIndex)
         endMidIndex = rawHTML.find("</font>", startMidIndex)
         index = endMidIndex
         midPrice = rawHTML[startMidIndex:endMidIndex]
 
-        #   Scrape for the high price
+        #   Scrape for the low price
         tempIndex = rawHTML.find("<td width=55", endMidIndex)
-        startHighIndex = rawHTML.find("$", tempIndex)
-        endHighIndex = rawHTML.find("</font>", startHighIndex)
-        index = endHighIndex
-        highPrice = rawHTML[startHighIndex:endHighIndex]
+        startLowIndex = rawHTML.find("$", tempIndex)
+        endLowIndex = rawHTML.find("</font>", startLowIndex)
+        index = endLowIndex
+        lowPrice = rawHTML[startLowIndex:endLowIndex]
 
         dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
         #dict = {"name": CardName[8:len(CardName)], "low": lowPrice[0:len(lowPrice)-6], "med": midPrice[0:len(midPrice)-6], "high": highPrice[0:len(highPrice)-6]}

--- a/scraper.py
+++ b/scraper.py
@@ -146,12 +146,12 @@ def getTCGPlayerSetPrices(cardSet):
         # if ("Token" not in CardName):
         #     if ("Emblem" not in CardName):
         if("T" not in Rarity):
-            if not CardName:
-                return setArray
             print CardName + "does not have emblem or token"
             CardName = CardName.decode("latin1")
             dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
             dict = OrderedDict(dict)
+            if not CardName:
+                return setArray
             setArray.append(dict)
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -142,12 +142,12 @@ def getTCGPlayerSetPrices(cardSet):
         index = endLowIndex
         lowPrice = rawHTML[startLowIndex:endLowIndex]
 
-        if not CardName:
-            return setArray
         # old way
         # if ("Token" not in CardName):
         #     if ("Emblem" not in CardName):
         if("T" not in Rarity):
+            if not CardName:
+                return setArray
             print CardName + "does not have emblem or token"
             dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
             dict = OrderedDict(dict)

--- a/scraper.py
+++ b/scraper.py
@@ -122,9 +122,14 @@ def getTCGPlayerSetPrices(cardSet):
         index = endLowIndex
         lowPrice = rawHTML[startLowIndex:endLowIndex]
 
-        dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
-        if((CardName.find("Emblem -") == -1) or (CardName.find("Token") == -1)):
-            dict = OrderedDict(dict)
-            setArray.append(dict)    
+
+        print "emblem " + str(("Emblem" in CardName))
+
+        if ("Token" not in CardName):
+            if ("Emblem" not in CardName):
+                print CardName + "does not have emblem"
+                dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
+                dict = OrderedDict(dict)
+                setArray.append(dict)   
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -162,7 +162,7 @@ def getTCGPlayerSetPrices(cardSet):
                     break
                 if("Checklist" in CardName):
                     continue
-                else if("(Oversized)" in Cardname):
+                else if("Oversized" in Cardname):
                     continue
                 else
                     setArray.append(dict)

--- a/scraper.py
+++ b/scraper.py
@@ -84,3 +84,46 @@ def getTCGPlayerPrices(cardName, cardSet):
     highPrice = rawHTML[startHighIndex:endHighIndex]
 
     return [lowPrice, midPrice, highPrice]
+
+def getTCGPlayerPrices(cardSet):
+        #   Open the TCGPlayer URL
+       # http://magic.tcgplayer.com/db/search_result.asp?Set_Name=Khans%20of%20Tarkir
+    tcgPlayerURL = "http://magic.tcgplayer.com/db/search_result.asp?Set_Name=" + urllib.quote(cardSet)
+    htmlFile = urllib.urlopen(tcgPlayerURL)
+    rawHTML = htmlFile.read()
+    setArray = []
+
+while tempIndex != "-1":
+
+    tempIndex = rawHTML.find('magic_single_card.asp', index)
+    startNameIndex = rawHTML.find('?cn=', tempIndex)
+    endNameIndex = rawHTML.find('&sn', startNameIndex)
+    CardName = rawHTML[startNameIndex:endNameIndex]
+
+    #   Scrape for the low price
+    tempIndex = rawHTML.find('bgcolor=#D9FCD1 class=default_8>', index)
+    if(tempIndex == "-1")
+        break
+    startLowIndex = rawHTML.find("\">$", tempIndex)
+    endLowIndex = rawHTML.find("<", startLowIndex)
+    index = endLowIndex
+    lowPrice = rawHTML[startLowIndex:endLowIndex]
+
+    #   Scrape for the mid price
+    tempIndex = rawHTML.find('bgcolor=#D1DFFC class=default_8>', index)
+    startMidIndex = rawHTML.find("\"$", tempIndex)
+    endMidIndex = rawHTML.find("<", startMidIndex)
+    index = endMidIndex
+    midPrice = rawHTML[startMidIndex:endMidIndex]
+
+    #   Scrape for the high price
+    tempIndex = rawHTML.find('bgcolor=#FCD1D1 class=default_8>', index)
+    startHighIndex = rawHTML.find("\"$", tempIndex)
+    endHighIndex = rawHTML.find("<", startHighIndex)
+    index = endHighIndex
+    highPrice = rawHTML[startHighIndex:endHighIndex]
+
+    dict = {'name': CardName, 'low': lowPrice, 'med': midPrice, 'high': highPrice}
+    setArray.append(dict)
+
+return setArray

--- a/scraper.py
+++ b/scraper.py
@@ -126,6 +126,5 @@ def getTCGPlayerSetPrices(cardSet):
         #dict = {"name": CardName[8:len(CardName)], "low": lowPrice[0:len(lowPrice)-6], "med": midPrice[0:len(midPrice)-6], "high": highPrice[0:len(highPrice)-6]}
         dict = OrderedDict(dict)
         setArray.append(dict)
-        print setArray
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -85,45 +85,44 @@ def getTCGPlayerPrices(cardName, cardSet):
 
     return [lowPrice, midPrice, highPrice]
 
-def getTCGPlayerPrices(cardSet):
-        #   Open the TCGPlayer URL
-       # http://magic.tcgplayer.com/db/search_result.asp?Set_Name=Khans%20of%20Tarkir
-    tcgPlayerURL = "http://magic.tcgplayer.com/db/search_result.asp?Set_Name=" + urllib.quote(cardSet)
+def getTCGPlayerSetPrices(cardSet):
+    #   Open the TCGPlayer URL
+    tcgPlayerURL = "http://magic.tcgplayer.com/db/price_guide.asp?setname="+cardSet# + urllib.quote(cardSet)    
     htmlFile = urllib.urlopen(tcgPlayerURL)
     rawHTML = htmlFile.read()
     setArray = []
+    tempIndex = 0
+    index = 0
+    while tempIndex != -1:
+        tempIndex = rawHTML.find("<td width=200", index)
+        startNameIndex = rawHTML.find("7>", tempIndex)
+        endNameIndex = rawHTML.find("</font>", startNameIndex)
+        CardName = rawHTML[startNameIndex:endNameIndex]
+        index = endNameIndex
 
-while tempIndex != "-1":
+        #   Scrape for the low price
+        tempIndex = rawHTML.find("<td width=55", index)
+        startLowIndex = rawHTML.find("$", tempIndex)
+        endLowIndex = rawHTML.find("</font>", startLowIndex)
+        index = endLowIndex
+        lowPrice = rawHTML[startLowIndex:endLowIndex]
 
-    tempIndex = rawHTML.find('magic_single_card.asp', index)
-    startNameIndex = rawHTML.find('?cn=', tempIndex)
-    endNameIndex = rawHTML.find('&sn', startNameIndex)
-    CardName = rawHTML[startNameIndex:endNameIndex]
+        #   Scrape for the mid price
+        tempIndex = rawHTML.find("<td width=55", endLowIndex)
+        startMidIndex = rawHTML.find("$", tempIndex)
+        endMidIndex = rawHTML.find("</font>", startMidIndex)
+        index = endMidIndex
+        midPrice = rawHTML[startMidIndex:endMidIndex]
 
-    #   Scrape for the low price
-    tempIndex = rawHTML.find('bgcolor=#D9FCD1 class=default_8>', index)
-    if(tempIndex == "-1")
-        break
-    startLowIndex = rawHTML.find("\">$", tempIndex)
-    endLowIndex = rawHTML.find("<", startLowIndex)
-    index = endLowIndex
-    lowPrice = rawHTML[startLowIndex:endLowIndex]
+        #   Scrape for the high price
+        tempIndex = rawHTML.find("<td width=55", endMidIndex)
+        startHighIndex = rawHTML.find("$", tempIndex)
+        endHighIndex = rawHTML.find("</font>", startHighIndex)
+        index = endHighIndex
+        highPrice = rawHTML[startHighIndex:endHighIndex]
 
-    #   Scrape for the mid price
-    tempIndex = rawHTML.find('bgcolor=#D1DFFC class=default_8>', index)
-    startMidIndex = rawHTML.find("\"$", tempIndex)
-    endMidIndex = rawHTML.find("<", startMidIndex)
-    index = endMidIndex
-    midPrice = rawHTML[startMidIndex:endMidIndex]
-
-    #   Scrape for the high price
-    tempIndex = rawHTML.find('bgcolor=#FCD1D1 class=default_8>', index)
-    startHighIndex = rawHTML.find("\"$", tempIndex)
-    endHighIndex = rawHTML.find("<", startHighIndex)
-    index = endHighIndex
-    highPrice = rawHTML[startHighIndex:endHighIndex]
-
-    dict = {'name': CardName, 'low': lowPrice, 'med': midPrice, 'high': highPrice}
-    setArray.append(dict)
-
-return setArray
+        dict = {"name": CardName[8:len(CardName)], "low": lowPrice[0:len(lowPrice)-6], "med": midPrice[0:len(midPrice)-6], "high": highPrice[0:len(highPrice)-6]}
+        setArray.append(dict)
+        print setArray
+    return setArray
+    # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -146,6 +146,8 @@ def getTCGPlayerSetPrices(cardSet):
         # if ("Token" not in CardName):
         #     if ("Emblem" not in CardName):
         if("T" not in Rarity):
+            if not CardName:
+                return setArray
             print CardName + "does not have emblem or token"
             dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
             dict = OrderedDict(dict)

--- a/scraper.py
+++ b/scraper.py
@@ -113,6 +113,13 @@ def getTCGPlayerSetPrices(cardSet):
         endNameIndex = rawHTML.find("</font>", startNameIndex)
         CardName = rawHTML[startNameIndex:endNameIndex]
         index = endNameIndex
+        
+        # Scrape for Type
+        tempIndex = rawHTML.find("<td width=120", index)
+        startTypeIndex = rawHTML.find(";", tempIndex)
+        endTypeIndex = rawHTML.find("</font>", startTypeIndex)
+        index = endTypeIndex
+        Type = rawHTML[startTypeIndex:endTypeIndex]
 
         # Scrape for Rarity
         tempIndex = rawHTML.find("<td width=30", index)
@@ -146,17 +153,18 @@ def getTCGPlayerSetPrices(cardSet):
         # if ("Token" not in CardName):
         #     if ("Emblem" not in CardName):
         if("T" not in Rarity):
-            print CardName + "does not have emblem or token"
-            CardName = CardName.decode("latin1")
-            dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
-            dict = OrderedDict(dict)
-            if not CardName:
-                break
-            if("Checklist" in CardName):
-                continue
-            else if("(Oversized)" in Cardname):
-                continue
-            else
-                setArray.append(dict)
+            if("Emblem" not in Type):
+                print CardName + "does not have emblem or token"
+                CardName = CardName.decode("latin1")
+                dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
+                dict = OrderedDict(dict)
+                if not CardName:
+                    break
+                if("Checklist" in CardName):
+                    continue
+                else if("(Oversized)" in Cardname):
+                    continue
+                else
+                    setArray.append(dict)
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -152,7 +152,11 @@ def getTCGPlayerSetPrices(cardSet):
             dict = OrderedDict(dict)
             if not CardName:
                 break
-            if("Checklist" not in CardName):
+            if("Checklist" in CardName):
+                continue
+            else if("(Oversized)" in Cardname):
+                continue
+            else
                 setArray.append(dict)
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -63,28 +63,41 @@ def getTCGPlayerPrices(cardName, cardSet):
     htmlFile = urllib.urlopen(tcgPlayerURL)
     rawHTML = htmlFile.read()
 
+    # Scrape for Normal prices
+    normalIndex = rawHTML.find('<b>Normal</b>')
+
     #   Scrape for the low price
-    tempIndex = rawHTML.find('>L:')
+    tempIndex = rawHTML.find(">Low:", normalIndex)
     startLowIndex = rawHTML.find("$", tempIndex)
     endLowIndex = rawHTML.find("<", startLowIndex)
 
     lowPrice = rawHTML[startLowIndex:endLowIndex]
 
     #   Scrape for the mid price
-    tempIndex = rawHTML.find('>M:')
+    tempIndex = rawHTML.find('>Median:', normalIndex)
     startMidIndex = rawHTML.find("$", tempIndex)
     endMidIndex = rawHTML.find("<", startMidIndex)
     
     midPrice = rawHTML[startMidIndex:endMidIndex]
 
     #   Scrape for the high price
-    tempIndex = rawHTML.find('>H:')
+    tempIndex = rawHTML.find('>High:', normalIndex)
     startHighIndex = rawHTML.find("$", tempIndex)
     endHighIndex = rawHTML.find("<", startHighIndex)
     
     highPrice = rawHTML[startHighIndex:endHighIndex]
 
-    return [lowPrice, midPrice, highPrice]
+    #Scrape for Foil Price
+    foilIndex = rawHTML.find('<b>Foil</b>')
+
+    #   Scrape for the mid price
+    tempIndex = rawHTML.find('>Median:', foilIndex)
+    startMidFoilIndex = rawHTML.find("$", tempIndex)
+    endMidFoilIndex = rawHTML.find("<", startMidFoilIndex)
+    
+    foilPrice = rawHTML[startMidFoilIndex:endMidFoilIndex]
+
+    return [lowPrice, midPrice, highPrice, foilPrice]
 
 def getTCGPlayerSetPrices(cardSet):
     #   Open the TCGPlayer URL

--- a/scraper.py
+++ b/scraper.py
@@ -150,8 +150,8 @@ def getTCGPlayerSetPrices(cardSet):
             CardName = CardName.decode("latin1")
             dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
             dict = OrderedDict(dict)
+            if not CardName:
+                continue
             setArray.append(dict)
-            #if not CardName:
-             #   break;
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -4,7 +4,7 @@
 
 import urllib
 import logging
-from Collections import OrderedDict
+from collections import OrderedDict
 
 #
 #   Retrieves a URL to the card's image as represented by http://magiccards.info

--- a/scraper.py
+++ b/scraper.py
@@ -150,8 +150,8 @@ def getTCGPlayerSetPrices(cardSet):
             CardName = CardName.decode("latin1")
             dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
             dict = OrderedDict(dict)
-            if not CardName:
-                return setArray
             setArray.append(dict)
+            #if not CardName:
+             #   break;
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -114,6 +114,13 @@ def getTCGPlayerSetPrices(cardSet):
         CardName = rawHTML[startNameIndex:endNameIndex]
         index = endNameIndex
 
+        # Scrape for Rarity
+        tempIndex = rawHTML.find("<td width=30", index)
+        startRareIndex = rawHTML.find(";", tempIndex)
+        endRareIndex = rawHTML.find("</font>", startRareIndex)
+        index = endRareIndex
+        Rarity = rawHTML[startRareIndex:endRareIndex]
+
         #   Scrape for the high price
         tempIndex = rawHTML.find("<td width=55", index)
         startHighIndex = rawHTML.find("$", tempIndex)
@@ -135,14 +142,13 @@ def getTCGPlayerSetPrices(cardSet):
         index = endLowIndex
         lowPrice = rawHTML[startLowIndex:endLowIndex]
 
-
-        print "emblem " + str(("Emblem" in CardName))
-
-        if ("Token" not in CardName):
-            if ("Emblem" not in CardName):
-                print CardName + "does not have emblem"
-                dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
-                dict = OrderedDict(dict)
-                setArray.append(dict)   
+        # old way
+        # if ("Token" not in CardName):
+        #     if ("Emblem" not in CardName):
+        if("T" not in Rarity):
+            print CardName + "does not have emblem or token"
+            dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
+            dict = OrderedDict(dict)
+            setArray.append(dict)   
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -113,41 +113,6 @@ def getTCGPlayerSetPrices(cardSet):
         endNameIndex = rawHTML.find("</font>", startNameIndex)
         CardName = rawHTML[startNameIndex:endNameIndex]
         index = endNameIndex
-        
-        #check to see if cards that are not in MO, but are priced as if.        
-        if(cardSet == "Magic Origins"):
-            if("Aegis Angel" in CardName):
-                continue
-            elif(CardName == "Divine Verdict"):
-                continue
-            elif(CardName == "Eagle of the Watch"):
-                continue
-            elif(CardName == "Serra Angel"):
-                continue
-            elif(CardName == "Into the Void"):
-                continue
-            elif(CardName == "Mahamoti Djinn"):
-                continue
-            elif(CardName == "Weave Fate"):
-                continue
-            elif(CardName == "Flesh to Dust"):
-                continue
-            elif(CardName == "Mind Rot"):
-                continue
-            elif(CardName == "Nightmare"):
-                continue
-            elif(CardName == "Sengir Vampire"):
-                continue
-            elif(CardName == "Fiery Hellhound"):
-                continue
-            elif(CardName == "Shivan Dragon"):
-                continue
-            elif(CardName == "Plummet"):
-                continue
-            elif(CardName == "Prized Unicorn"):
-                continue
-            elif(CardName == "Terra Stomper"):
-                continue
 
         # Scrape for Type
         tempIndex = rawHTML.find("<td width=120", index)

--- a/scraper.py
+++ b/scraper.py
@@ -142,15 +142,15 @@ def getTCGPlayerSetPrices(cardSet):
         index = endLowIndex
         lowPrice = rawHTML[startLowIndex:endLowIndex]
 
+        if not CardName:
+            return setArray
         # old way
         # if ("Token" not in CardName):
         #     if ("Emblem" not in CardName):
         if("T" not in Rarity):
-            if not CardName:
-                return setArray
             print CardName + "does not have emblem or token"
             dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
             dict = OrderedDict(dict)
-            setArray.append(dict)   
+            setArray.append(dict)
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -152,8 +152,7 @@ def getTCGPlayerSetPrices(cardSet):
             dict = OrderedDict(dict)
             if not CardName:
                 break
-            if("Checklist" in CardName):
-                break
-            setArray.append(dict)
+            if("Checklist" not in CardName):
+                setArray.append(dict)
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -152,6 +152,8 @@ def getTCGPlayerSetPrices(cardSet):
             dict = OrderedDict(dict)
             if not CardName:
                 break
+            if("Checklist" in CardName):
+                break
             setArray.append(dict)
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -107,13 +107,48 @@ def getTCGPlayerSetPrices(cardSet):
     setArray = []
     tempIndex = 0
     index = 0
-    while tempIndex != -1:
+    while tempIndex != -1:        
         tempIndex = rawHTML.find("<td width=200", index)
         startNameIndex = rawHTML.find("7>", tempIndex)
         endNameIndex = rawHTML.find("</font>", startNameIndex)
         CardName = rawHTML[startNameIndex:endNameIndex]
         index = endNameIndex
         
+        #check to see if cards that are not in MO, but are priced as if.        
+        if(cardSet == "Magic Origins"):
+            if("Aegis Angel" in CardName):
+                continue
+            elif(CardName == "Divine Verdict"):
+                continue
+            elif(CardName == "Eagle of the Watch"):
+                continue
+            elif(CardName == "Serra Angel"):
+                continue
+            elif(CardName == "Into the Void"):
+                continue
+            elif(CardName == "Mahamoti Djinn"):
+                continue
+            elif(CardName == "Weave Fate"):
+                continue
+            elif(CardName == "Flesh to Dust"):
+                continue
+            elif(CardName == "Mind Rot"):
+                continue
+            elif(CardName == "Nightmare"):
+                continue
+            elif(CardName == "Sengir Vampire"):
+                continue
+            elif(CardName == "Fiery Hellhound"):
+                continue
+            elif(CardName == "Shivan Dragon"):
+                continue
+            elif(CardName == "Plummet"):
+                continue
+            elif(CardName == "Prized Unicorn"):
+                continue
+            elif(CardName == "Terra Stomper"):
+                continue
+
         # Scrape for Type
         tempIndex = rawHTML.find("<td width=120", index)
         startTypeIndex = rawHTML.find(";", tempIndex)

--- a/scraper.py
+++ b/scraper.py
@@ -149,6 +149,7 @@ def getTCGPlayerSetPrices(cardSet):
             if not CardName:
                 return setArray
             print CardName + "does not have emblem or token"
+            CardName = CardName.decode("latin1")
             dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
             dict = OrderedDict(dict)
             setArray.append(dict)

--- a/scraper.py
+++ b/scraper.py
@@ -119,21 +119,21 @@ def getTCGPlayerSetPrices(cardSet):
         startHighIndex = rawHTML.find("$", tempIndex)
         endHighIndex = rawHTML.find("</font>", startHighIndex)
         index = endHighIndex
-        highPrice = rawHTML[startHighIndex:endHighIndex]
+        highPrice = rawHTML[startHighIndex+1:endHighIndex]
 
         #   Scrape for the mid price
         tempIndex = rawHTML.find("<td width=55", endHighIndex)
         startMidIndex = rawHTML.find("$", tempIndex)
         endMidIndex = rawHTML.find("</font>", startMidIndex)
         index = endMidIndex
-        midPrice = rawHTML[startMidIndex:endMidIndex]
+        midPrice = rawHTML[startMidIndex+1:endMidIndex]
 
         #   Scrape for the low price
         tempIndex = rawHTML.find("<td width=55", endMidIndex)
         startLowIndex = rawHTML.find("$", tempIndex)
         endLowIndex = rawHTML.find("</font>", startLowIndex)
         index = endLowIndex
-        lowPrice = rawHTML[startLowIndex:endLowIndex]
+        lowPrice = rawHTML[startLowIndex+1:endLowIndex]
 
 
         print "emblem " + str(("Emblem" in CardName))

--- a/scraper.py
+++ b/scraper.py
@@ -162,9 +162,9 @@ def getTCGPlayerSetPrices(cardSet):
                     break
                 if("Checklist" in CardName):
                     continue
-                else if("Oversized" in Cardname):
+                elif("Oversized" in CardName):
                     continue
-                else
+                else:
                     setArray.append(dict)
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -125,6 +125,7 @@ def getTCGPlayerSetPrices(cardSet):
         dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
         #dict = {"name": CardName[8:len(CardName)], "low": lowPrice[0:len(lowPrice)-6], "med": midPrice[0:len(midPrice)-6], "high": highPrice[0:len(highPrice)-6]}
         dict = OrderedDict(dict)
-        setArray.append(dict)
+        if((CardName.find("Emblem -") == -1) or (CardName.find("Token") == -1)):
+            setArray.append(dict)    
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -123,9 +123,8 @@ def getTCGPlayerSetPrices(cardSet):
         lowPrice = rawHTML[startLowIndex:endLowIndex]
 
         dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
-        #dict = {"name": CardName[8:len(CardName)], "low": lowPrice[0:len(lowPrice)-6], "med": midPrice[0:len(midPrice)-6], "high": highPrice[0:len(highPrice)-6]}
-        dict = OrderedDict(dict)
         if((CardName.find("Emblem -") == -1) or (CardName.find("Token") == -1)):
+            dict = OrderedDict(dict)
             setArray.append(dict)    
     return setArray
     # return "HI"

--- a/scraper.py
+++ b/scraper.py
@@ -87,7 +87,7 @@ def getTCGPlayerPrices(cardName, cardSet):
 
 def getTCGPlayerSetPrices(cardSet):
     #   Open the TCGPlayer URL
-    tcgPlayerURL = "http://magic.tcgplayer.com/db/price_guide.asp?setname="+cardSet# + urllib.quote(cardSet)    
+    tcgPlayerURL = "http://magic.tcgplayer.com/db/price_guide.asp?setname="+urllib.quote(cardSet)    
     htmlFile = urllib.urlopen(tcgPlayerURL)
     rawHTML = htmlFile.read()
     setArray = []

--- a/scraper.py
+++ b/scraper.py
@@ -119,21 +119,21 @@ def getTCGPlayerSetPrices(cardSet):
         startHighIndex = rawHTML.find("$", tempIndex)
         endHighIndex = rawHTML.find("</font>", startHighIndex)
         index = endHighIndex
-        highPrice = rawHTML[startHighIndex+1:endHighIndex]
+        highPrice = rawHTML[startHighIndex:endHighIndex]
 
         #   Scrape for the mid price
         tempIndex = rawHTML.find("<td width=55", endHighIndex)
         startMidIndex = rawHTML.find("$", tempIndex)
         endMidIndex = rawHTML.find("</font>", startMidIndex)
         index = endMidIndex
-        midPrice = rawHTML[startMidIndex+1:endMidIndex]
+        midPrice = rawHTML[startMidIndex:endMidIndex]
 
         #   Scrape for the low price
         tempIndex = rawHTML.find("<td width=55", endMidIndex)
         startLowIndex = rawHTML.find("$", tempIndex)
         endLowIndex = rawHTML.find("</font>", startLowIndex)
         index = endLowIndex
-        lowPrice = rawHTML[startLowIndex+1:endLowIndex]
+        lowPrice = rawHTML[startLowIndex:endLowIndex]
 
 
         print "emblem " + str(("Emblem" in CardName))

--- a/scraper.py
+++ b/scraper.py
@@ -4,6 +4,7 @@
 
 import urllib
 import logging
+from Collections import OrderedDict
 
 #
 #   Retrieves a URL to the card's image as represented by http://magiccards.info
@@ -121,7 +122,9 @@ def getTCGPlayerSetPrices(cardSet):
         index = endHighIndex
         highPrice = rawHTML[startHighIndex:endHighIndex]
 
-        dict = {"name": CardName[8:len(CardName)], "low": lowPrice[0:len(lowPrice)-6], "med": midPrice[0:len(midPrice)-6], "high": highPrice[0:len(highPrice)-6]}
+        dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
+        #dict = {"name": CardName[8:len(CardName)], "low": lowPrice[0:len(lowPrice)-6], "med": midPrice[0:len(midPrice)-6], "high": highPrice[0:len(highPrice)-6]}
+        dict = OrderedDict(dict)
         setArray.append(dict)
         print setArray
     return setArray

--- a/scraper.py
+++ b/scraper.py
@@ -151,7 +151,7 @@ def getTCGPlayerSetPrices(cardSet):
             dict = (("name", CardName[8:len(CardName)]), ("low", lowPrice[0:len(lowPrice)-6]), ("med", midPrice[0:len(midPrice)-6]), ("high", highPrice[0:len(highPrice)-6]))
             dict = OrderedDict(dict)
             if not CardName:
-                continue
+                break
             setArray.append(dict)
     return setArray
     # return "HI"


### PR DESCRIPTION
Hi bedoherty, 
I forked your repository and have added a function that retrieves the whole set's price at once. I'm currently working on a android app, and found that getting each's card price one by one proved to be slower than it would be if I had the whole sets priced and then linked them up that way. I also edited your single card price to code that should work, but I haven't tested it because my computer is blocked from tcg or something... ( they have the db/magic_single_search redirecting to their shop page... so the code is meant to parse that... also grabbed the foil price.) I got to test it once before they blocked it, and I think it probably doesn't work because it's grabbing html before it redirects.... anyway, I hope you can use this. (also, I've uploaded a version of it to my own googleappsengine site so that i wasn't causing your server any problems.)
